### PR TITLE
Allow passing multiple -t params to cucumber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## v 0.3.4
+* Added logical and operation to tags
+
 ## v 0.2.3
 * Fixed 'executable' rename to 'modulePath'
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,7 +12,8 @@ module.exports = function (grunt) {
       files: 'features',
       options: {
         steps: 'features/step_definitions',
-        format: 'pretty'
+        format: 'pretty',
+        tags: '~@dontrun1;~@dontrun2;@dorun,@anotherdorun'
       }
     }
   });

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ this represents boolean NOT. Example:
 by a comma, which represents logical OR. Example:
 `tags: '@dev,@wip'`
 
+Also, you can separate tags with semicolon to represent logic AND. Example:
+`tags: '~@dontrunthis;@dontrunthiseither'` 
+
 #### format
 Type: `String`
 

--- a/features/Testing.feature
+++ b/features/Testing.feature
@@ -3,7 +3,31 @@ Feature: Testing
   I want a Testing.feature file
   So that I can test the cucumber-js-task
 
+  @dorun
   Scenario: A test scenario
     Given I have the number 1 and 3
     When I add them together
     Then I should have 4
+
+  @anotherdorun
+  Scenario: Another test scenario
+    Given I have the number 1 and 3
+    When I add them together
+    Then I should have 4
+
+  Scenario: A test scenario that should be omitted because it doesnt have tag
+    Given I have the number 1 and 3
+    When I add them together
+    Then I should have 100
+
+  @dontrun1
+  Scenario: Should Not Run - always fails
+    Given I have the number 1 and 4
+    When I add them together
+    Then I should have 3
+
+  @dontrun2
+  Scenario: Should Not Run - always fails
+    Given I have the number 1 and 5
+    When I add them together
+    Then I should have 3

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-cucumber-sigma",
   "description": "Grunt task for running Cucumber.js",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "homepage": "https://github.com/i-e-b/grunt-cucumber-js",
   "author": {
     "name": "Iain Ballard",

--- a/tasks/cucumber-js-task.js
+++ b/tasks/cucumber-js-task.js
@@ -64,8 +64,10 @@ module.exports = function (grunt) {
         }
 
         if (! _.isEmpty(tags)) {
-            execOptions.push('-t');
-            execOptions.push(tags);
+            tags.split(';').forEach( function (item) {
+              execOptions.push('-t');
+              execOptions.push(item);
+            });
         }
 
         if (! _.isEmpty(format)) {


### PR DESCRIPTION
To emulate logical AND operator. This basicly allows user to emit multiple tags from being run or combining tests which have multiple tags to actually run.

For example, we have '@slow' tests and '@veryslow' tests and normal once .. we with this patch we can now omit both from being executed when running developer mode with tags: '~@slow;~@veryslow' which did not work before. 
