### PR TITLE
Added support for specifying multiple tags in an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## v0.3.4
+* Added support specifying multiple tags in an array
+
 ## v 0.2.3
 * Fixed 'executable' rename to 'modulePath'
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ when this option is specified, and all loading becomes explicit.
 Files under directories named "support" are always loaded first.
 
 #### tags
-Type: `String`
+Type: `String|Array`
 
 Default: `''`
 
@@ -60,6 +60,11 @@ this represents boolean NOT. Example:
  A tag expression can have several tags separated
 by a comma, which represents logical OR. Example:
 `tags: '@dev,@wip'`
+
+A tag expression can have an array of tags to be applied,
+this represents a logical AND. Example:
+
+`tags: ['@dev',@wip]`
 
 #### format
 Type: `String`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-cucumber-sigma",
   "description": "Grunt task for running Cucumber.js",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "homepage": "https://github.com/i-e-b/grunt-cucumber-js",
   "author": {
     "name": "Iain Ballard",

--- a/tasks/cucumber-js-task.js
+++ b/tasks/cucumber-js-task.js
@@ -63,9 +63,13 @@ module.exports = function (grunt) {
             execOptions.push(steps);
         }
 
-        if (! _.isEmpty(tags)) {
-            execOptions.push('-t');
-            execOptions.push(tags);
+        if (! _.isEmpty(tags)) 
+		{
+			var allTags = [].concat(tags);
+			
+			allTags.forEach(t => {
+				execOptions.push('-t', t);
+			});
         }
 
         if (! _.isEmpty(format)) {


### PR DESCRIPTION
Allow us to specify multiple tags for logical AND in the cucumber grunt task
